### PR TITLE
Bump json-yaml-validate to v5

### DIFF
--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -18,6 +18,6 @@ jobs:
 
       - name: json-yaml-validate
         id: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@250fa0dc7d7f4a888b24dc2a6b2ff589753fba70 # pin@v3
+        uses: GrantBirki/json-yaml-validate@3ff75979f3b21171f2e8a44705f0ff4bed30bbc0 # pin@v5.0.0
         with:
           comment: "true" # enable comment mode


### PR DESCRIPTION
Updates the json-yaml-validate workflow action to the pinned v5.0.0 SHA.